### PR TITLE
Fix BusBoy constructor error

### DIFF
--- a/tools/task-viewer/package.json
+++ b/tools/task-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shrimp-task-viewer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Web-based viewer for Shrimp Task Manager data with comprehensive testing suite (port 9998)",
   "main": "server.js",
   "bin": {

--- a/tools/task-viewer/server.js
+++ b/tools/task-viewer/server.js
@@ -4,7 +4,7 @@ const http = require('http');
 const fs = require('fs').promises;
 const path = require('path');
 const os = require('os');
-const Busboy = require('busboy');
+const busboy = require('busboy');
 
 // Version information
 const VERSION = '2.0.0';
@@ -140,11 +140,11 @@ async function startServer() {
             
             if (contentType.includes('multipart/form-data')) {
                 // Handle multipart form data with busboy
-                const busboy = new Busboy({ headers: req.headers });
+                const bb = busboy({ headers: req.headers });
                 let name = null;
                 let taskFileContent = null;
                 
-                busboy.on('field', (fieldname, value) => {
+                bb.on('field', (fieldname, value) => {
                     if (fieldname === 'name') {
                         name = value;
                     } else if (fieldname === 'taskFile') {
@@ -152,7 +152,7 @@ async function startServer() {
                     }
                 });
                 
-                busboy.on('finish', async () => {
+                bb.on('finish', async () => {
                     if (!name || !taskFileContent) {
                         res.writeHead(400, { 'Content-Type': 'text/plain' });
                         res.end('Missing name or taskFile');
@@ -175,7 +175,7 @@ async function startServer() {
                     }
                 });
                 
-                req.pipe(busboy);
+                req.pipe(bb);
             } else {
                 // Handle URL-encoded form data
                 let body = '';


### PR DESCRIPTION
### Description

I got a runtime error adding new profile:

```
Open your browser to view tasks!

[...]/mcp-shrimp-task-manager/tools/task-viewer/server.js:143
                const busboy = new Busboy({ headers: req.headers });
                               ^

TypeError: Busboy is not a constructor
    at Server.<anonymous> (/Users/jm/dev/tools/mcp-shrimp-task-manager/tools/task-viewer/server.js:143:32)
    at Server.emit (node:events:513:28)
    at parserOnIncoming (node:_http_server:1153:12)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)

Node.js v23.5.0
```

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

- [ ] `npm run test` (following the project's testing guidelines)
- [X] Manual testing with the following configuration:

**Test Configuration**:
*   **Client**: Cursor
*   **OS**: macOS
*   **Node.js version**: Node.js v23.5.0

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (`README.md`, `CHANGELOG.md`)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked to ensure my PR is focused on a single feature/fix
- [x] I have updated the version number in `package.json`
