### PR TITLE
Fix Windows path encoding for relative paths in mcp.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## [1.0.22] - 2025-10-02
+
+### Fixed
+
+- Decode URL-encoded `file://` roots on Windows when resolving `DATA_DIR`, preventing paths like `e%3A` from being used and ensuring files are written to the correct drive.
+
 ## [1.0.21] - 2025-01-13
 
 ### Added
@@ -32,6 +38,7 @@
 - **Node.js HTTP Server**: RESTful API endpoints for task and profile management
 - **HTML5 Drag & Drop**: Native browser API for intuitive tab reordering
 - **CSS Grid & Flexbox**: Responsive layout system with mobile-first approach
+
 ### Changed
 
 - Updated documentation to reflect new configuration options (99baa0f, 8771a5b)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-shrimp-task-manager",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Shrimp Task Manager is a task tool built for AI Agents, emphasizing chain-of-thought, reflection, and style consistency. It converts natural language into structured dev tasks with dependency tracking and iterative refinement, enabling agent-like developer behavior in reasoning AI systems",
   "main": "dist/index.js",
   "type": "module",

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -52,14 +52,25 @@ export async function getDataDir(): Promise<string> {
           root.uri.startsWith("file://")
         );
         if (firstFileRoot) {
-          // 從 file:// URI 中提取實際路徑
-          // Extract actual path from file:// URI
+          // 從 file:// URI 中提取實際路徑並進行 URL 解碼
+          // Extract actual path from file:// URI and URL decode
           // Windows: file:///C:/path -> C:/path
           // Unix: file:///path -> /path
-          if (process.platform === 'win32') {
-            rootPath = firstFileRoot.uri.replace("file:///", "").replace(/\//g, "\\");
+          let rawPath: string;
+          if (process.platform === "win32") {
+            rawPath = firstFileRoot.uri
+              .replace("file:///", "")
+              .replace(/\//g, "\\");
           } else {
-            rootPath = firstFileRoot.uri.replace("file://", "");
+            rawPath = firstFileRoot.uri.replace("file://", "");
+          }
+
+          try {
+            // URL decode the path to handle %3A -> : conversion and other encoded characters
+            rootPath = decodeURIComponent(rawPath);
+          } catch (error) {
+            // If URL decoding fails, use the raw path as fallback
+            rootPath = rawPath;
           }
         }
       }


### PR DESCRIPTION
# Description

Relative filepaths on Windows were causing `:` to be encoded as `%3A`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `npm run test` (following the project's testing guidelines)
- [x] Manual testing with the following configuration:

**Test Configuration**:
*   **Client**: Cursor
*   **OS**: Windows
*   **Node.js version**: `v22.15.1`

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`README.md`, `CHANGELOG.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
   - N/A
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked to ensure my PR is focused on a single feature/fix
- [x] I have updated the version number in `package.json`

